### PR TITLE
fix: resolve conflict between profile creation and fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import Login from "./Auth/Login";
 import Home from "./components/Home";
 import SignUp from "./Auth/SignUp";
@@ -9,18 +9,16 @@ import Layout from "./pages/Layout";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/signup" element={<SignUp />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/calendar" element={<CalendarPage />} />
-        <Route path="/profile" element={<ProfilePage />} />
-        <Route path='/' element={<Layout />}>
-          <Route index element={<Home />} /> {/* Default route */}
-          <Route path="recipes" element={<RecipesPage />} />
-        </Route>
-      </Routes>
-    </Router>
+    <Routes>
+      <Route path="/signup" element={<SignUp />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/calendar" element={<CalendarPage />} />
+      <Route path="/profile" element={<ProfilePage />} />
+      <Route path='/' element={<Layout />}>
+        <Route index element={<Home />} /> {/* Default route */}
+        <Route path="recipes" element={<RecipesPage />} />
+      </Route>
+    </Routes>
   );
 }
 

--- a/src/Auth/SignUp.tsx
+++ b/src/Auth/SignUp.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthContext";
-import { createNewUser } from "../api/userApi";
 import signUpBox from "../assets/sign-up-box.svg";
 import background from "../assets/background.png";
 
@@ -46,26 +45,10 @@ const SignUp: React.FC = () => {
     event.preventDefault();
 
     try {
-      const result = await signUp(signUpForm.email, signUpForm.password); // Call signUp from AuthContext
-
-      if (
-        result.success &&
-        result.data &&
-        result.data.user &&
-        result.data.session
-      ) {
-        await createNewUser(
-          result.data.user.id,
-          signUpForm.username,
-          result.data.session.access_token
-        );
-      } else {
-        console.error("Sign-up failed:", result);
-      }
+      const result = await signUp(signUpForm.username, signUpForm.email, signUpForm.password); // Call signUp from AuthContext
+      result.success ? navigate("/") : console.error("Sign-up failed:", result);
     } catch (error) {
       console.error("An error occured: ", error);
-    } finally {
-      navigate("/");
     }
   };
 

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -2,7 +2,6 @@ const baseUrl = import.meta.env.VITE_API_BASE_URL
 
 // Make a POST request to create a new user profile
 export const createNewUser = async (id:string, username:string, token:string) => {
-    console.log("creating new user")
     try {
         const response = await fetch(`${baseUrl}/users/`, {
             method: "POST",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,14 @@
 import { createRoot } from 'react-dom/client';
 import { AuthContextProvider } from './Auth/AuthContext.tsx';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
 
 
 createRoot(document.getElementById('root')!).render(
-  <AuthContextProvider>
-    <App />
-  </AuthContextProvider>
+  <BrowserRouter>
+    <AuthContextProvider>
+      <App />
+    </AuthContextProvider>
+  </BrowserRouter>
 );


### PR DESCRIPTION
- Moved the `createNewUser` function from the sign-up form submission logic into the `signUp` method within the `AuthContext`
- Added a conditional check to only trigger the `getUserProfile` function if the current path is not `/signup`, preventing unnecessary profile fetching during the sign-up process