### PR TITLE
Fix: stats only adding once bug  + disable cook button

### DIFF
--- a/src/components/RecipeModal.tsx
+++ b/src/components/RecipeModal.tsx
@@ -55,7 +55,7 @@ const RecipeModal: React.FC<ModalProps> = ({
   const mealTypes = ["Breakfast", "Lunch", "Dinner"];
   const [message, setMessage] = useState<string>("");
 
-  const { user, session, isLoading, setIsLoading } = useAuth();
+  const { user, session, isLoading, setIsLoading, setUser } = useAuth();
   const navigate = useNavigate();
 
   // Select a day for the meal plan
@@ -201,6 +201,10 @@ const RecipeModal: React.FC<ModalProps> = ({
           );
           showMessage(`Recipe added to meal plan: Wisdom +20`);
           setMealPlan([...mealPlan, newMeal.mealPlan]);
+          // update current page user wisdom exp so that a user can add muliple recipes in a row and get all the wisdom points
+          const updatedUser = { ...user };
+          updatedUser.pet_wisdom_exp = updatedUser.pet_wisdom_exp + 20;
+          setUser(updatedUser);
         } else {
           showMessage("Error adding recipe to meal plan, try again");
         }
@@ -268,6 +272,19 @@ const RecipeModal: React.FC<ModalProps> = ({
             "protein",
             eatenProteinPercent
           );
+          // update current page user data to make sure eating multiple things in a row gives all the points
+          const updatedUser = { ...user };
+          if (proteinPoints)
+            updatedUser.pet_protein_exp =
+              updatedUser.pet_protein_exp + proteinPoints;
+          if (fatPoints)
+            updatedUser.pet_fat_exp = updatedUser.pet_fat_exp + fatPoints;
+          if (carbPoints)
+            updatedUser.pet_carb_exp = updatedUser.pet_carb_exp + carbPoints;
+          if (caloriePoints)
+            updatedUser.pet_calorie_exp =
+              updatedUser.pet_calorie_exp + caloriePoints;
+          setUser(updatedUser);
 
           showMessage(
             `Strength +${proteinPoints} Defense +${fatPoints} Dexterity +${carbPoints} Stamina +${caloriePoints}`
@@ -405,7 +422,8 @@ const RecipeModal: React.FC<ModalProps> = ({
                         {handlePointCalc(
                           handleRatioCalc(
                             user?.daily_fat_goal,
-                            selectedRecipe.nutrition.macronutrients.fat.percentage
+                            selectedRecipe.nutrition.macronutrients.fat
+                              .percentage
                           )
                         )}
                       </p>

--- a/src/components/RecipeModal.tsx
+++ b/src/components/RecipeModal.tsx
@@ -54,6 +54,7 @@ const RecipeModal: React.FC<ModalProps> = ({
   const daysOfTheWeek = ["S", "M", "T", "W", "TH", "F", "S"];
   const mealTypes = ["Breakfast", "Lunch", "Dinner"];
   const [message, setMessage] = useState<string>("");
+  const [isButtonDisabled, setButtonDisabled] = useState(false);
 
   const { user, session, isLoading, setIsLoading, setUser } = useAuth();
   const navigate = useNavigate();
@@ -314,8 +315,11 @@ const RecipeModal: React.FC<ModalProps> = ({
             // Display notification for achievement unlocked
             showMessage(activityResult.message);
           }
+          // reenable cook button once finished (both in try and catch block)
+          setButtonDisabled(false);
         } catch (error: any) {
           console.error("Error updating meal plan:", error);
+          setButtonDisabled(false);
         }
       }
     }
@@ -514,7 +518,12 @@ const RecipeModal: React.FC<ModalProps> = ({
                     ? "bg-[#19243e] text-[#ebd6aa]"
                     : "bg-gray-400 text-gray-300"
                 }`}
-                onClick={handleCookedClick}
+                onClick={() => {
+                  if (!isButtonDisabled) {
+                    setButtonDisabled(true);
+                    handleCookedClick();
+                  }
+                }}
               >
                 <FaCheckCircle />
                 <h1

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -35,21 +35,21 @@ const ProfilePage: React.FC = () => {
 
   const colorPicker = (exp: number) => {
     if (exp < 17) {
-      return "[&::-webkit-progress-value]:bg-red-500";
+      return "[&::-webkit-progress-value]:bg-green-200";
     }
     if (exp < 34) {
-      return "[&::-webkit-progress-value]:bg-orange-500";
+      return "[&::-webkit-progress-value]:bg-green-300";
     }
     if (exp < 51) {
-      return "[&::-webkit-progress-value]:bg-amber-500";
+      return "[&::-webkit-progress-value]:bg-green-400";
     }
     if (exp < 68) {
-      return "[&::-webkit-progress-value]:bg-yellow-500";
+      return "[&::-webkit-progress-value]:bg-green-500";
     }
     if (exp < 85) {
-      return "[&::-webkit-progress-value]:bg-lime-500";
+      return "[&::-webkit-progress-value]:bg-green-600";
     }
-    return "[&::-webkit-progress-value]:bg-green-500";
+    return "[&::-webkit-progress-value]:bg-green-700";
   };
 
   const checkDailyStatColors = async () => {

--- a/src/util/statCalc.ts
+++ b/src/util/statCalc.ts
@@ -14,28 +14,28 @@ export const calcRemainderExp = (exp: number) => {
 // Handle point calc based on goal/actual ratio
 export const handlePointCalc = (ratio: number) => {
   if (ratio > 0.9) {
-    return 50;
-  }
-  if (ratio > 0.8) {
-    return 45;
-  }
-  if (ratio > 0.7) {
-    return 40;
-  }
-  if (ratio > 0.6) {
     return 35;
   }
-  if (ratio > 0.5) {
-    return 30;
+  if (ratio > 0.8) {
+    return 29;
   }
-  if (ratio > 0.4) {
-    return 25;
+  if (ratio > 0.7) {
+    return 24;
   }
-  if (ratio > 0.3) {
+  if (ratio > 0.6) {
     return 20;
   }
-  if (ratio > 0.2) {
+  if (ratio > 0.5) {
+    return 17;
+  }
+  if (ratio > 0.4) {
     return 15;
+  }
+  if (ratio > 0.3) {
+    return 13;
+  }
+  if (ratio > 0.2) {
+    return 11;
   }
   return 10;
 };


### PR DESCRIPTION
 - fixed stats only adding once for all 5 stats in recipe modal
 - disable the cook button if clicked once and reenable it once handleCookClick finishes
 - lowered the amount of points received from the point calc
 - changed colors on profile page to light green / dark green

resolves #156 